### PR TITLE
pdftk in other location can be invoked without a PDFTK_PATH env

### DIFF
--- a/pypdftk.py
+++ b/pypdftk.py
@@ -16,6 +16,8 @@ if os.getenv('PDFTK_PATH'):
     PDFTK_PATH = os.getenv('PDFTK_PATH')
 else:
     PDFTK_PATH = '/usr/bin/pdftk'
+    if not os.path.isfile(PDFTK_PATH):
+        PDFTK_PATH = 'pdftk'
 
 
 def check_output(*popenargs, **kwargs):


### PR DESCRIPTION
The path of pdftk may be various, for example <code>/usr/local/bin/pdftk</code>.
However we don't need the `PDFTK_PATH` environ var, we can invoke the `pdftk` directly.
