### PR TITLE
Pmartynov hotfix/issue 12 Fixed Unit Tests

### DIFF
--- a/pypdftk.py
+++ b/pypdftk.py
@@ -85,7 +85,11 @@ def dump_data_fields(pdf_path):
         Return list of dicts of all fields in a PDF.
     '''
     cmd = "%s %s dump_data_fields" % (PDFTK_PATH, pdf_path)
-    field_data = map(lambda x: x.split(': ', 1), run_command(cmd, True))
+    # Either can return strings with :
+    #    field_data = map(lambda x: x.decode("utf-8").split(': ', 1), run_command(cmd, True))
+    # Or return bytes with : (will break tests)
+    #    field_data = map(lambda x: x.split(b': ', 1), run_command(cmd, True))
+    field_data = map(lambda x: x.decode("utf-8").split(': ', 1), run_command(cmd, True))
     fields = [list(group) for k, group in itertools.groupby(field_data, lambda x: len(x) == 1) if not k]
     return map(dict, fields)
 

--- a/test.py
+++ b/test.py
@@ -47,12 +47,12 @@ class TestPyPDFTK(unittest.TestCase):
         result = pypdftk.fill_form(TEST_XPDF_PATH, datas=SAMPLE_DATA2, flatten=False)
         result_data = ordered(pypdftk.dump_data_fields(result))
         expected_data = ordered(json.loads(read(TEST_XPDF_FILLED_DATA_DUMP)))
-        self.assertEqual(result_data, expected_data)
+        self.assertCountEqual(list(result_data), [dict(i) for i in expected_data])
 
     def test_dump_data_fields(self):
         result_data = ordered(pypdftk.dump_data_fields(TEST_XPDF_PATH))
         expected_data = ordered(json.loads(read(TEST_XPDF_DATA_DUMP)))
-        self.assertEqual(result_data, expected_data)
+        self.assertCountEqual(list(result_data), [dict(i) for i in expected_data])
 
     def test_concat(self):
         total_pages = pypdftk.get_num_pages(TEST_PDF_PATH)

--- a/test.py
+++ b/test.py
@@ -3,6 +3,8 @@ import os
 import unittest
 import json
 from tempfile import mkdtemp
+# Needed for comparison of XFDF XML
+import xml.etree.ElementTree as ET
 
 import pypdftk
 
@@ -79,7 +81,13 @@ class TestPyPDFTK(unittest.TestCase):
         xfdf_path = pypdftk.gen_xfdf(SAMPLE_DATA)
         xfdf = read(xfdf_path)
         expected = read(TEST_XFDF_PATH)
-        self.assertEqual(xfdf, expected)
+        # XML can have sibling elements in different order. So: 
+        # * Parse the XML, get list of the root's children, convert to string, sort
+        xfdf_standard_order     = [ET.tostring(i) for i in list(ET.fromstring(xfdf).iter())]
+        expected_standard_order = [ET.tostring(i) for i in list(ET.fromstring(expected).iter())]
+        xfdf_standard_order.sort()
+        expected_standard_order.sort()
+        self.assertEqual(xfdf_standard_order, expected_standard_order)
 
     def test_replace_page_at_begin(self):
         total_pages = pypdftk.get_num_pages(TEST_PDF_PATH)


### PR DESCRIPTION
This is a fix for PR's #18 not passing tests (which is a fix for #12)

One large change is now now the commands return UTF-8 encoded strings. This can be changed back to binary (although then the tests will have to be fixed).

Also: 

- some python3 iterated lists need to be unpacked and compared with `unittest` properly (order agnostic)
- The sub elements in the xml returned by xfdf are parsed, converted to strings, and sorted, by `xml.etree.ElementTree` before being compared, so the order becomes deterministic