### PR TITLE
Remove Unnecessary XFDF Temp File

### DIFF
--- a/pypdftk.py
+++ b/pypdftk.py
@@ -81,6 +81,7 @@ def fill_form(pdf_path, datas={}, out_file=None, flatten=True):
     finally:
         if handle:
             os.close(handle)
+    os.remove(tmp_fdf)
     return out_file
 
 def dump_data_fields(pdf_path):


### PR DESCRIPTION
Really small change - when I use `fill_form`, it leaves a XFDF temporary file remaining. As far as I can tell, since `gen_xfdf` uses `mkstemp` not `TemporaryFile,` the `tempfile` module won't do any fancy delete-on-close.

Although, since this was taken care of with the `cleanOnFail` clause, I apologize if I don't understand well enough

Thanks!