### PR TITLE
Update for Windows Python2/3

### DIFF
--- a/pypdftk.py
+++ b/pypdftk.py
@@ -153,7 +153,7 @@ def gen_xfdf(datas={}):
     </fields>
 </xfdf>""" % "\n".join(fields)
     handle, out_file = tempfile.mkstemp()
-    f = open(out_file, 'wb')
+    f = os.fdopen(handle, 'wb')
     f.write((tpl.encode('UTF-8')))
     f.close()
     return out_file


### PR DESCRIPTION
running in windows python versions 2/3 gives an file permission error [WinError 32] on line 92.  Windows cannot remove the temp file because its is "opened" during creation of tempfile on line 163 and its handle is never closed.  Changing to os.fdopen() and passing handle instead of file name takes care of the bug.

I tested on windows with python 2/3 and it works with no error now. (at least pypdftk.fill_form() works)