### PR TITLE
Fix tests

### DIFF
--- a/test_files/form-filled.json
+++ b/test_files/form-filled.json
@@ -43,7 +43,7 @@
     "FieldValue": ""
   },
   {
-    "FieldStateOption": "Sweden",
+    "FieldStateOption": "Estonia",
     "FieldFlags": "393216",
     "FieldNameAlt": "Use selection or write country name",
     "FieldName": "Country Combo Box",
@@ -70,16 +70,17 @@
     "FieldValue": ""
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldNameAlt": "Car driving license",
     "FieldName": "Driving License Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yellow",
+    "FieldStateOption": "Grey",
     "FieldFlags": "131072",
     "FieldNameAlt": "Select from colour spectrum",
     "FieldName": "Favourite Colour List Box",
@@ -89,43 +90,48 @@
     "FieldValue": "Red"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 1 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 2 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Yes",
     "FieldValue": "Yes"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 3 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Yes"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 4 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 5 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {

--- a/test_files/form.json
+++ b/test_files/form.json
@@ -43,7 +43,7 @@
     "FieldValue": ""
   },
   {
-    "FieldStateOption": "Sweden",
+    "FieldStateOption": "Estonia",
     "FieldFlags": "393216",
     "FieldNameAlt": "Use selection or write country name",
     "FieldName": "Country Combo Box",
@@ -70,16 +70,17 @@
     "FieldValue": ""
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldNameAlt": "Car driving license",
     "FieldName": "Driving License Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yellow",
+    "FieldStateOption": "Grey",
     "FieldFlags": "131072",
     "FieldNameAlt": "Select from colour spectrum",
     "FieldName": "Favourite Colour List Box",
@@ -89,43 +90,48 @@
     "FieldValue": "Red"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 1 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 2 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Yes",
     "FieldValue": "Yes"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 3 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 4 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {
-    "FieldStateOption": "Yes",
+    "FieldStateOption": "Off",
     "FieldFlags": "0",
     "FieldName": "Language 5 Check Box",
     "FieldType": "Button",
     "FieldJustification": "Left",
+    "FieldValueDefault": "Off",
     "FieldValue": "Off"
   },
   {


### PR DESCRIPTION
Resolve differences between output of PDFtk dump_data_fields function and the JSON files.

When I first cloned this repository two tests were failing:

- test_fill_form
- test_dump_data_fields

This occurred because the dump_data_fields() output, using the form.pdf file in the test directory, did not match the form.json file. I updated both form.json and form-filled.json to match PDFtk output (and the content of form.pdf). I've run the tests successfully with Python 2.7 and 3.7.