### PR TITLE
feat: added support for drop_xfa argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Fill a PDF with given data and returns the output PDF path
 -  ``out_file`` (default=auto) : output PDF path. will use tempfile if
    not provided
 -  ``flatten`` (default=True) : flatten the final PDF
+-  ``drop_xfa`` (default=False) : omit XFA data from the output PDF
 
 ``concat``
 ~~~~~~~~~~

--- a/pypdftk.py
+++ b/pypdftk.py
@@ -84,7 +84,7 @@ def get_pages(pdf_path, ranges=[], out_file=None):
     return out_file
 
 
-def fill_form(pdf_path, datas={}, out_file=None, flatten=True):
+def fill_form(pdf_path, datas={}, out_file=None, flatten=True, drop_xfa=False):
     '''
         Fills a PDF form with given dict input data.
         Return temp file if no out_file provided.
@@ -99,6 +99,8 @@ def fill_form(pdf_path, datas={}, out_file=None, flatten=True):
     cmd = "%s %s fill_form %s output %s" % (PDFTK_PATH, pdf_path, tmp_fdf, out_file)
     if flatten:
         cmd += ' flatten'
+    if drop_xfa:
+        cmd += ' drop_xfa'
     try:
         run_command(cmd, True)
     except:


### PR DESCRIPTION
Added `drop_xfa` argument to the `fill_form` method, this is useful when filling a PDF containing XFA data.

Currently if we try to fill or flatten a PDF containing XFA DATA, it gives following warning.
```
Warning: input PDF is not an acroform, so its fields were not filled.
```
Using the `drop_xfa` argument helps in resolving this issue.