### PR TITLE
Added Get Pages By Page Range

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ _defaults: &defaults
     - run:
         name: dependencies
         command: |
+          sudo apt-get update
           sudo apt-get install pdftk
           sudo pip install pytest
     - run:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Merge multiple PDFs into one single file and returns the output PDF path
  - `files` : list of PDF files to concatenate
  - `out_file` (default=auto) : output PDF path. will use tempfile if not provided
 
+### `get_pages`
+Concatenate a list of page ranges into one single file and returns the output PDF path
+ - `pdf_path` : input PDF
+ - `ranges`  (default=```[]```) : ```[]``` for clone, ```[[2]]``` for extracting 2nd page, ```[[1],[2,5],[3]]``` for concatenating pages 1, 2-5, 3
+ - `out_file` (default=auto) : output PDF path. will use tempfile if not provided
+
 ### `split`
 Split a single PDF in many pages and return a list of pages paths
  - `pdf_path` : input PDF

--- a/pypdftk.py
+++ b/pypdftk.py
@@ -56,6 +56,33 @@ def get_num_pages(pdf_path):
             return int(line.split(':')[1])
     return 0
 
+def get_pages(pdf_path, ranges=[], out_file=None):
+    ''' 
+    Concatenate a list of page ranges into one single file
+    Return temp file if no out_file provided.
+    '''
+    cleanOnFail = False
+    handle = None
+    pageRanges = []
+    if not out_file:
+        cleanOnFail = True
+        handle, out_file = tempfile.mkstemp()
+
+    for range in ranges:
+        pageRanges.append("-".join([str(i) for i in range]))
+        
+    args = [PDFTK_PATH, pdf_path, 'cat'] + pageRanges + ['output', out_file]
+    try:
+        run_command(args)
+    except:
+        if cleanOnFail:
+            os.remove(out_file)
+        raise
+    finally:
+        if handle:
+            os.close(handle)
+    return out_file
+
 
 def fill_form(pdf_path, datas={}, out_file=None, flatten=True):
     '''

--- a/test.py
+++ b/test.py
@@ -38,6 +38,18 @@ def ordered(obj):
     else:
         return obj
 
+# Converts a page range list into the number of pages
+def rangeCount(ranges):
+    count = 0
+    for range in ranges:
+        if len(range)==1:
+            count += 1
+        elif len(range)==2:
+            count += abs(range[0]-range[1]) + 1
+        else:
+            raise ValueError(str(range)+" contains more than 2 values")
+    return count
+
 class TestPyPDFTK(unittest.TestCase):
     def test_get_num_pages(self):
         num = pypdftk.get_num_pages(TEST_PDF_PATH)
@@ -59,6 +71,31 @@ class TestPyPDFTK(unittest.TestCase):
         output_file = pypdftk.concat([TEST_PDF_PATH, TEST_PDF_PATH, TEST_PDF_PATH])
         concat_total_pages = pypdftk.get_num_pages(output_file)
         self.assertEqual(total_pages * 3, concat_total_pages)
+
+
+    def test_get_pages_clone(self):
+        total_pages = pypdftk.get_num_pages(TEST_PDF_PATH)
+        output_file = pypdftk.get_pages(TEST_PDF_PATH,[])
+        concat_total_pages = pypdftk.get_num_pages(output_file)
+        self.assertEqual(total_pages, concat_total_pages)
+
+    def test_get_pages_single(self):
+        pageRanges = [[1]]
+        output_file = pypdftk.get_pages(TEST_PDF_PATH,pageRanges)
+        concat_total_pages = pypdftk.get_num_pages(output_file)
+        self.assertEqual(rangeCount(pageRanges), concat_total_pages)
+
+    def test_get_pages_range(self):
+        pageRanges = [[2,5]]
+        output_file = pypdftk.get_pages(TEST_PDF_PATH,pageRanges)
+        concat_total_pages = pypdftk.get_num_pages(output_file)
+        self.assertEqual(rangeCount(pageRanges), concat_total_pages)
+
+    def test_get_pages_single_range(self):
+        pageRanges = [[1],[2,5]]
+        output_file = pypdftk.get_pages(TEST_PDF_PATH,pageRanges)
+        concat_total_pages = pypdftk.get_num_pages(output_file)
+        self.assertEqual(rangeCount(pageRanges), concat_total_pages)
 
     def test_split(self):
         total_pages = pypdftk.get_num_pages(TEST_PDF_PATH)


### PR DESCRIPTION
Found that the pypdftk was missing the basic ability to concatenate a list of page ranges, from an input pdf, into one single file. Implemented this feature into a get_pages() function and wrote test cases that tested an empty page range list, a page range list of length 1 and a page range list of length 2