### PR TITLE
Adding flatten only feature without filling forms

### DIFF
--- a/pypdftk.py
+++ b/pypdftk.py
@@ -113,6 +113,33 @@ def fill_form(pdf_path, datas={}, out_file=None, flatten=True, drop_xfa=False):
     os.remove(tmp_fdf)
     return out_file
 
+def flatten_only(pdf_path, out_file=None, flatten=True, drop_xfa=True):
+    '''
+        Flattens a PDF.
+        Return temp file if no out_file provided.
+    '''
+    cleanOnFail = False
+    handle = None
+    if not out_file:
+        cleanOnFail = True
+        handle, out_file = tempfile.mkstemp()
+
+    cmd = "%s %s output %s" % (PDFTK_PATH, pdf_path, out_file)
+    if flatten:
+        cmd += ' flatten'
+    if drop_xfa:
+        cmd += ' drop_xfa'
+    try:
+        run_command(cmd, True)
+    except:
+        if cleanOnFail:
+            os.remove(out_file)
+        raise
+    finally:
+        if handle:
+            os.close(handle)
+    return out_file
+
 def dump_data_fields(pdf_path, add_id=False):
     '''
         Return list of dicts of all fields in a PDF.


### PR DESCRIPTION
Adding flatten only feature without filling forms.

@revolunet 

When I was trying to flatten some multilayer PDFs using **fill_form()** (passing datas argument as blank), it is showing a warning(screenshot attached).
<img width="508" alt="Screenshot 2021-10-04 at 5 34 05 PM" src="https://user-images.githubusercontent.com/76515176/135848349-727112e2-2647-46c4-9b58-a5ed338d16f4.png">

I am not sure if https://github.com/revolunet/pypdftk/pull/46 would solve this issue.

Please do release the new version of the library as the documentation is updated with **drop_xfa** argument in **fill_form()**,
 but we cannot use it as it is not released.